### PR TITLE
Add copy to clipboard button

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,6 +124,7 @@
           Select level and damage type to generate
         </div>
       </div>
+      <button type="button" class="btn btn-secondary mt-2" id="copyButton">Copy to Clipboard</button>
     </div>
   </div>
 </div>

--- a/script.js
+++ b/script.js
@@ -86,3 +86,16 @@ document
         "No examples available";
     }
   });
+
+// Function to copy the stat block text to the clipboard
+function copyStatBlock() {
+  const statText = document.getElementById("statBlock").innerText;
+  navigator.clipboard
+    .writeText(statText)
+    .catch((err) => console.error("Could not copy stat block:", err));
+}
+
+// Event listener for the copy button
+document
+  .getElementById("copyButton")
+  .addEventListener("click", copyStatBlock);


### PR DESCRIPTION
## Summary
- add a "Copy to Clipboard" button near the stat block
- implement JS function to copy stat block text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872ae117450832fb09688cc2d649817