### PR TITLE
Add visual feedback when copying stat block

### DIFF
--- a/script.js
+++ b/script.js
@@ -92,6 +92,18 @@ function copyStatBlock() {
   const statText = document.getElementById("statBlock").innerText;
   navigator.clipboard
     .writeText(statText)
+    .then(() => {
+      const btn = document.getElementById("copyButton");
+      const originalText = btn.textContent;
+      btn.textContent = "Copied!";
+      btn.classList.remove("btn-secondary");
+      btn.classList.add("btn-success");
+      setTimeout(() => {
+        btn.textContent = originalText;
+        btn.classList.remove("btn-success");
+        btn.classList.add("btn-secondary");
+      }, 2000);
+    })
     .catch((err) => console.error("Could not copy stat block:", err));
 }
 


### PR DESCRIPTION
## Summary
- improve copy to clipboard button by showing `Copied!` feedback

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872af1fd6dc832f8ccc4fa32dcde818